### PR TITLE
feat: defineAchievements utility, standalone react package, and useUnlockedCount hook

### DIFF
--- a/apps/example/src/achievements.ts
+++ b/apps/example/src/achievements.ts
@@ -1,43 +1,41 @@
-import { createAchievements } from "achievements-react";
-import { localStorageAdapter } from "achievements";
+import {
+  defineAchievements,
+  createAchievements,
+  localStorageAdapter,
+} from "achievements-react";
 
-export type AchievementId =
-  | "first-visit"
-  | "returning"
-  | "night-owl"
-  | "click-frenzy"
-  | "explorer";
-
-export const definitions = [
+export const definitions = defineAchievements([
   {
-    id: "first-visit" as const,
+    id: "first-visit",
     label: "First Contact",
     description: "Initialized session for the first time.",
   },
   {
-    id: "returning" as const,
+    id: "returning",
     label: "Persistent Agent",
     description: "Returned for a subsequent session.",
   },
   {
-    id: "night-owl" as const,
+    id: "night-owl",
     label: "Night Protocol",
     description: "Operating between 00:00 and 05:00.",
     hidden: true,
   },
   {
-    id: "click-frenzy" as const,
+    id: "click-frenzy",
     label: "Input Overflow",
     description: "Registered 50 consecutive inputs.",
     maxProgress: 50,
   },
   {
-    id: "explorer" as const,
+    id: "explorer",
     label: "Full Traversal",
     description: "Accessed all system modules.",
     maxProgress: 3,
   },
-];
+]);
+
+export type AchievementId = (typeof definitions)[number]["id"];
 
 export const {
   engine,
@@ -46,6 +44,7 @@ export const {
   useIsUnlocked,
   useProgress,
   useAchievementToast,
+  useUnlockedCount,
 } = createAchievements<AchievementId>({
   definitions,
   storage: localStorageAdapter("achievements-demo"),

--- a/apps/example/src/components/Sidebar.tsx
+++ b/apps/example/src/components/Sidebar.tsx
@@ -1,5 +1,4 @@
-import { useAchievements, definitions } from "../achievements";
-import { useUnlockedCount } from "../hooks/useUnlockedCount";
+import { useAchievements, useUnlockedCount, definitions } from "../achievements";
 import { AchievementCard } from "./AchievementCard";
 
 export function Sidebar() {

--- a/apps/example/src/hooks/useUnlockedCount.ts
+++ b/apps/example/src/hooks/useUnlockedCount.ts
@@ -1,9 +1,0 @@
-import { useEffect, useState } from "react";
-import { engine } from "../achievements";
-
-/** Subscribes directly to the engine — no React context required. */
-export function useUnlockedCount() {
-  const [count, setCount] = useState(() => engine.getState().unlockedIds.size);
-  useEffect(() => engine.subscribe((s) => setCount(s.unlockedIds.size)), []);
-  return count;
-}

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -129,6 +129,10 @@ export function createAchievements<TId extends string>(
     return new Set(unlockedIds);
   }
 
+  function getUnlockedCount(): number {
+    return unlockedIds.size;
+  }
+
   function getDefinition(id: TId): AchievementDef<TId> | undefined {
     return config.definitions.find((d) => d.id === id);
   }
@@ -151,6 +155,7 @@ export function createAchievements<TId extends string>(
     isUnlocked,
     getProgress,
     getUnlocked,
+    getUnlockedCount,
     getState,
     getDefinition,
     subscribe,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export { createAchievements } from "./engine";
 export { localStorageAdapter, inMemoryAdapter } from "./adapters";
+export { defineAchievements } from "./types";
 export type { AchievementDef, AchievementState, AchievementEngine, StorageAdapter } from "./types";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,14 @@
+/**
+ * Define an array of achievement definitions with full type inference.
+ * IDs are inferred as literal types, so you can derive the ID union with:
+ *   type AchievementId = typeof definitions[number]["id"]
+ */
+export function defineAchievements<
+  const T extends ReadonlyArray<AchievementDef<string>>,
+>(definitions: T): T {
+  return definitions;
+}
+
 // Achievement definition provided by the consumer
 export type AchievementDef<TId extends string> = {
   id: TId;
@@ -48,6 +59,7 @@ export type AchievementEngine<TId extends string> = {
   isUnlocked(id: TId): boolean;
   getProgress(id: TId): number;
   getUnlocked(): ReadonlySet<TId>;
+  getUnlockedCount(): number;
   getState(): AchievementState<TId>;
   getDefinition(id: TId): AchievementDef<TId> | undefined;
 

--- a/packages/react/src/factory.tsx
+++ b/packages/react/src/factory.tsx
@@ -7,10 +7,11 @@ import {
   useIsUnlocked as useIsUnlockedHook,
   useProgress as useProgressHook,
   useAchievementToast as useAchievementToastHook,
+  useUnlockedCount as useUnlockedCountHook,
 } from "./hooks";
 
 type Config<TId extends string> = {
-  definitions: Array<AchievementDef<TId>>;
+  definitions: ReadonlyArray<AchievementDef<TId>>;
   storage?: StorageAdapter;
   onUnlock?: (id: TId) => void;
 };
@@ -52,5 +53,8 @@ export function createAchievements<TId extends string>(config: Config<TId>) {
 
     /** Reactive `{ queue, dismiss }` for toast notifications. */
     useAchievementToast: () => useAchievementToastHook<TId>(),
+
+    /** Reactive count of unlocked achievements — re-renders only when the count changes. */
+    useUnlockedCount: () => useUnlockedCountHook<TId>(),
   };
 }

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -24,6 +24,11 @@ export function useProgress<TId extends string>(
   return { progress, max };
 }
 
+/** Reactive count of unlocked achievements — re-renders only when the count changes. */
+export function useUnlockedCount<TId extends string>(): number {
+  return useEngineState<TId, number>((s) => s.unlockedIds.size);
+}
+
 /** Reactive toast queue + dismiss helper. */
 export function useAchievementToast<TId extends string>() {
   const engine = useEngine<TId>();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,7 @@
 export { createAchievements } from "./factory";
 export { AchievementsProvider } from "./context";
-export { useAchievements, useIsUnlocked, useProgress, useAchievementToast } from "./hooks";
+export { useAchievements, useIsUnlocked, useProgress, useAchievementToast, useUnlockedCount } from "./hooks";
+
+// Re-export everything from the core package so achievements-react is standalone
+export { defineAchievements, createAchievements as createAchievementsEngine, localStorageAdapter, inMemoryAdapter } from "achievements";
+export type { AchievementDef, AchievementState, AchievementEngine, StorageAdapter } from "achievements";


### PR DESCRIPTION
## Summary

- Add `defineAchievements()` to core — infers literal ID types from the definitions array so consumers no longer need `as const` on each `id` and can derive the ID union via `typeof definitions[number]["id"]`
- Re-export all core features (`defineAchievements`, `localStorageAdapter`, `inMemoryAdapter`, types) from `achievements-react` so it can be installed standalone without a separate `achievements` dependency
- Add `getUnlockedCount()` to `AchievementEngine` and a corresponding `useUnlockedCount` hook that re-renders only when the count changes
- Update example app to use all new APIs and remove the hand-rolled local `useUnlockedCount` hook

## Test plan

- [x] `pnpm tsc --noEmit` passes in `packages/core` and `apps/example`
- [x] Example app renders with `useUnlockedCount` displayed in the sidebar
- [x] Unlocking achievements increments the count reactively
- [x] Resetting resets the count to 0