### PR TITLE
feat: add collectItem, getItems, and setMaxProgress APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/node_modules/
 **/dist/
+**/*.tsbuildinfo

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -5,6 +5,7 @@ import { AppHeader } from "./components/AppHeader";
 import { ClickFrenzySection } from "./components/ClickFrenzySection";
 import { ExplorerSection } from "./components/ExplorerSection";
 import { ManualSection } from "./components/ManualSection";
+import { CollectorSection } from "./components/CollectorSection";
 import { Toast } from "./components/Toast";
 
 // ─── Session init (runs once on mount) ───────────────────────────────────────
@@ -38,6 +39,7 @@ function Layout() {
         <ClickFrenzySection />
         <ExplorerSection />
         <ManualSection />
+        <CollectorSection />
       </main>
 
       <Toast />

--- a/apps/example/src/achievements.ts
+++ b/apps/example/src/achievements.ts
@@ -33,6 +33,18 @@ export const definitions = defineAchievements([
     description: "Accessed all system modules.",
     maxProgress: 3,
   },
+  {
+    id: "scanner",
+    label: "Network Scanner",
+    description: "Scanned 4 unique network nodes.",
+    maxProgress: 4,
+  },
+  {
+    id: "full-coverage",
+    label: "Full Coverage",
+    description: "Scanned every node in the network.",
+    // No static maxProgress — set at runtime via setMaxProgress
+  },
 ]);
 
 export type AchievementId = (typeof definitions)[number]["id"];

--- a/apps/example/src/components/CollectorSection.tsx
+++ b/apps/example/src/components/CollectorSection.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { engine, useAchievements, useIsUnlocked, useProgress } from "../achievements";
+
+const INITIAL_NODES = [
+  { id: "node-alpha", label: "alpha", desc: "Primary relay" },
+  { id: "node-beta", label: "beta", desc: "Secondary relay" },
+  { id: "node-gamma", label: "gamma", desc: "Tertiary relay" },
+  { id: "node-delta", label: "delta", desc: "Backup relay" },
+] as const;
+
+const EXTRA_NODES = [
+  { id: "node-epsilon", label: "epsilon", desc: "Deep node" },
+  { id: "node-zeta", label: "zeta", desc: "Dark node" },
+] as const;
+
+export function CollectorSection() {
+  const { collectItem, setMaxProgress } = useAchievements();
+  const { progress: scannerProgress } = useProgress("scanner");
+  const scannerUnlocked = useIsUnlocked("scanner");
+  const coverageUnlocked = useIsUnlocked("full-coverage");
+
+  const [expanded, setExpanded] = useState(false);
+  const nodes = expanded ? [...INITIAL_NODES, ...EXTRA_NODES] : INITIAL_NODES;
+
+  // Initialize from persisted engine state so scanned set survives page refresh
+  const [scanned, setScanned] = useState<Set<string>>(
+    () => new Set(engine.getItems("scanner")),
+  );
+
+  // Keep full-coverage's maxProgress in sync with the current node count
+  useEffect(() => {
+    setMaxProgress("full-coverage", nodes.length);
+  }, [nodes.length, setMaxProgress]);
+
+  function scan(nodeId: string) {
+    if (scanned.has(nodeId)) return;
+    collectItem("scanner", nodeId);
+    collectItem("full-coverage", nodeId);
+    setScanned((prev) => new Set(prev).add(nodeId));
+  }
+
+  return (
+    <section className="py-10 border-t border-edge">
+      <div className="flex items-center gap-3 mb-2.5">
+        <span className="font-mono text-[11px] text-faint tracking-widest">04</span>
+        <code className="font-mono text-[12px] text-code px-2.5 py-1 bg-well border border-edge rounded">
+          collectItem("scanner", nodeId)
+        </code>
+      </div>
+      <h2 className="text-[22px] font-medium tracking-tight text-bright mb-2">
+        Node Scanner
+      </h2>
+      <p className="text-[14px] text-body leading-[1.65] mb-6 max-w-[480px]">
+        Scan unique network nodes to unlock achievements. Scanning the same node twice
+        is idempotent. Expanding the network calls{" "}
+        <code className="font-mono text-[12px] text-code bg-well px-1.5 py-0.5 rounded border border-edge">
+          setMaxProgress
+        </code>{" "}
+        to raise the target dynamically.
+      </p>
+
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        {nodes.map((node) => {
+          const done = scanned.has(node.id);
+          const allDone = coverageUnlocked;
+          return (
+            <button
+              key={node.id}
+              className={[
+                "p-4 flex flex-col gap-1.5 text-left rounded-xl border transition-all duration-150",
+                done || allDone
+                  ? "border-accent-mid bg-accent-dim cursor-default"
+                  : "border-edge bg-surface cursor-pointer hover:border-edge-bright hover:bg-well",
+              ].join(" ")}
+              onClick={() => scan(node.id)}
+              disabled={done || allDone}
+            >
+              <span
+                className={`font-mono text-[13px] ${done ? "text-accent" : "text-bright"}`}
+              >
+                {node.label}
+              </span>
+              <span className="text-[11px] text-faint leading-snug">{node.desc}</span>
+              <span
+                className={`font-mono text-[10px] mt-1 tracking-wide ${
+                  done ? "text-accent-mid" : "text-faint"
+                }`}
+              >
+                {done ? "✓ scanned" : "→ scan"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-4 flex-wrap">
+        <p className="font-mono text-[11px] text-faint tracking-wide">
+          {scannerProgress} / 4 unique nodes scanned
+          <span className="ml-3 text-faint">
+            · {scanned.size} / {nodes.length} for full coverage
+          </span>
+        </p>
+
+        {!expanded && !coverageUnlocked && (
+          <button
+            className="font-mono text-[11px] text-faint border border-edge rounded px-2.5 py-1 hover:text-bright hover:border-edge-bright transition-all duration-150 cursor-pointer"
+            onClick={() => setExpanded(true)}
+          >
+            + expand network
+          </button>
+        )}
+      </div>
+
+      {!scannerUnlocked && (
+        <p className="font-mono text-[10px] text-faint mt-2 tracking-wide opacity-60">
+          scan {4 - scannerProgress} more unique node{4 - scannerProgress !== 1 ? "s" : ""} to unlock
+          Network Scanner
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/example/tsconfig.tsbuildinfo
+++ b/apps/example/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.tsx","./src/achievements.ts","./src/main.tsx","./src/components/achievementcard.tsx","./src/components/appheader.tsx","./src/components/clickfrenzysection.tsx","./src/components/explorersection.tsx","./src/components/manualsection.tsx","./src/components/progressbar.tsx","./src/components/sidebar.tsx","./src/components/toast.tsx"],"version":"5.9.3"}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,8 @@ pre-commit:
   parallel: true
   jobs:
     - name: format
-      run: pnpm format:check
+      run: pnpm format
+      stage_fixed: true
 
     - name: lint
       run: pnpm lint

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,6 +50,16 @@ export type AchievementEngine<TId extends string> = {
   setProgress(id: TId, value: number): void;
   /** Increment progress by 1. Auto-unlocks if the new value >= maxProgress. */
   incrementProgress(id: TId): void;
+  /**
+   * Add a unique string item to this achievement's tracked set.
+   * Calls setProgress(id, items.size) after insertion. Idempotent.
+   */
+  collectItem(id: TId, item: string): void;
+  /**
+   * Update the maxProgress for an achievement at runtime.
+   * Enables auto-unlock when progress reaches the new max.
+   */
+  setMaxProgress(id: TId, max: number): void;
   /** Remove an ID from the toast queue (call after displaying the notification). */
   dismissToast(id: TId): void;
   /** Wipe all state from memory and storage. */
@@ -58,6 +68,8 @@ export type AchievementEngine<TId extends string> = {
   // --- Reads (synchronous snapshots) ---
   isUnlocked(id: TId): boolean;
   getProgress(id: TId): number;
+  /** Return the set of items collected for this achievement via collectItem(). */
+  getItems(id: TId): ReadonlySet<string>;
   getUnlocked(): ReadonlySet<TId>;
   getUnlockedCount(): number;
   getState(): AchievementState<TId>;


### PR DESCRIPTION
## Summary

Closes #5, #6, #7.

- **`collectItem(id, item)`** — adds a string to a persistent `Set<string>` tied to an achievement, then calls `setProgress(id, set.size)`. Idempotent: duplicate items are ignored. Items are persisted to storage under the key `"items"` and hydrated on init.
- **`getItems(id)`** — returns a `ReadonlySet<string>` snapshot of the items collected for an achievement.
- **`setMaxProgress(id, max)`** — updates the effective `maxProgress` at runtime (in-memory only, not persisted). Re-evaluates the current progress immediately to trigger auto-unlock if the threshold is already met. Enables achievements whose total is only known at runtime (e.g. a server-driven post count).
- **`reset()`** updated to clear `items` state and remove the `"items"` storage key.

## Test plan

- [x] 30 unit tests pass (`pnpm -r test`)
- [x] Typechecks clean for core and react packages (`pnpm -r typecheck`)
- [x] Full build passes (`pnpm -r build`)
- [x] New `CollectorSection` in the example app demonstrates all three APIs:
  - Scan unique nodes → `collectItem` + `getItems` (idempotency visible in UI)
  - "Expand network" button → `setMaxProgress` with dynamic runtime total