### PR TITLE
chore: bump version to 0.2.0 and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.2.0 (2026-02-26)
+
+### Features
+
+- **`collectItem(id, item)`** — adds a string to a persistent `Set<string>` tied to an achievement and calls `setProgress(id, set.size)`. Idempotent: duplicate items are ignored. Items are persisted to storage under the key `"items"` and hydrated on init.
+- **`getItems(id)`** — returns a `ReadonlySet<string>` snapshot of collected items for an achievement.
+- **`setMaxProgress(id, max)`** — updates the effective `maxProgress` at runtime (in-memory only). Re-evaluates current progress immediately to trigger auto-unlock if the threshold is already met. Enables achievements whose total is only known at runtime (e.g. server-driven counts).
+- **`reset()`** now also clears `items` state and removes the `"items"` storage key.
+
+## 0.1.0 (2026-02-25)
+
+### Features
+
+- **`defineAchievements`** utility for declaring typed achievement definitions.
+- **`useUnlockedCount`** React hook for tracking the number of unlocked achievements.
+- Standalone `achievements-react` package with React 19+ bindings.
+- Framework-agnostic `achievements` core library.
+- Rolldown-based build pipeline with TypeScript declarations.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "achievements",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Framework-agnostic achievement tracking library",
   "files": [
     "dist"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "achievements-react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React bindings for the achievements library",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- Bumps `achievements` and `achievements-react` from `0.1.0` to `0.2.0`
- Adds `CHANGELOG.md` documenting all changes in 0.1.0 and 0.2.0

## What's in 0.2.0

- `collectItem(id, item)` — tracks unique string items per achievement (persisted, idempotent)
- `getItems(id)` — returns a `ReadonlySet<string>` snapshot of collected items
- `setMaxProgress(id, max)` — sets effective `maxProgress` at runtime and re-evaluates progress immediately
- `reset()` now also clears items state and storage key

## Test plan

- [x] Versions updated in `packages/core/package.json` and `packages/react/package.json`
- [x] `CHANGELOG.md` covers both 0.1.0 and 0.2.0 entries