### PR TITLE
feat: add anti-cheat system with pluggable HashAdapter

### DIFF
--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { engine, Provider, useAchievements } from "./achievements";
+import { engine, Provider, useAchievements, useTamperDetected } from "./achievements";
 import { Sidebar } from "./components/Sidebar";
 import { AppHeader } from "./components/AppHeader";
 import { ClickFrenzySection } from "./components/ClickFrenzySection";
@@ -7,6 +7,7 @@ import { ExplorerSection } from "./components/ExplorerSection";
 import { ManualSection } from "./components/ManualSection";
 import { CollectorSection } from "./components/CollectorSection";
 import { Toast } from "./components/Toast";
+import { JumpscarePage } from "./components/JumpscarePage";
 
 // ─── Session init (runs once on mount) ───────────────────────────────────────
 
@@ -50,6 +51,12 @@ function Layout() {
 // ─── Root ─────────────────────────────────────────────────────────────────────
 
 export default function App() {
+  const tamperKey = useTamperDetected();
+
+  if (tamperKey !== null) {
+    return <JumpscarePage tamperKey={tamperKey} />;
+  }
+
   return (
     <Provider>
       <SessionInit />

--- a/apps/example/src/achievements.ts
+++ b/apps/example/src/achievements.ts
@@ -57,6 +57,7 @@ export const {
   useProgress,
   useAchievementToast,
   useUnlockedCount,
+  useTamperDetected,
 } = createAchievements<AchievementId>({
   definitions,
   storage: localStorageAdapter("achievements-demo"),

--- a/apps/example/src/components/JumpscarePage.tsx
+++ b/apps/example/src/components/JumpscarePage.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+
+export function JumpscarePage({ tamperKey }: { tamperKey: string }) {
+  const [visible, setVisible] = useState(false);
+
+  // Slight delay so the transition feels like a system alarm kicking in
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-[#060008] overflow-hidden"
+      style={{
+        opacity: visible ? 1 : 0,
+        transition: "opacity 0.2s ease-in",
+      }}
+    >
+      {/* Animated scanlines */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,0,60,0.03) 2px, rgba(255,0,60,0.03) 4px)",
+        }}
+      />
+
+      {/* Red grid overlay */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(255,0,60,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,0,60,0.04) 1px, transparent 1px)",
+          backgroundSize: "40px 40px",
+        }}
+      />
+
+      {/* Pulsing red vignette */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background: "radial-gradient(ellipse at center, transparent 40%, rgba(180,0,30,0.35) 100%)",
+          animation: "pulse-vignette 1.2s ease-in-out infinite",
+        }}
+      />
+
+      <style>{`
+        @keyframes pulse-vignette {
+          0%, 100% { opacity: 1; }
+          50%       { opacity: 0.5; }
+        }
+        @keyframes glitch-h {
+          0%   { clip-path: inset(40% 0 55% 0); transform: translate(-4px, 0); }
+          20%  { clip-path: inset(10% 0 75% 0); transform: translate(4px, 0); }
+          40%  { clip-path: inset(70% 0 10% 0); transform: translate(-2px, 0); }
+          60%  { clip-path: inset(30% 0 50% 0); transform: translate(3px, 0); }
+          80%  { clip-path: inset(80% 0 5%  0); transform: translate(-3px, 0); }
+          100% { clip-path: inset(40% 0 55% 0); transform: translate(0, 0); }
+        }
+        .glitch-title {
+          position: relative;
+        }
+        .glitch-title::before,
+        .glitch-title::after {
+          content: attr(data-text);
+          position: absolute;
+          inset: 0;
+          animation: glitch-h 2.4s infinite linear;
+        }
+        .glitch-title::before {
+          color: #ff003c;
+          opacity: 0.7;
+          animation-delay: 0s;
+        }
+        .glitch-title::after {
+          color: #ff6090;
+          opacity: 0.5;
+          animation-delay: -1.2s;
+        }
+      `}</style>
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col items-center gap-8 px-8 text-center max-w-2xl">
+        {/* Warning icon */}
+        <div
+          className="text-7xl select-none"
+          style={{ filter: "drop-shadow(0 0 24px #ff003c)" }}
+        >
+          ☠
+        </div>
+
+        {/* Title */}
+        <h1
+          className="glitch-title font-mono text-4xl font-bold uppercase tracking-widest"
+          data-text="INTEGRITY BREACH"
+          style={{ color: "#ff003c", textShadow: "0 0 20px #ff003c, 0 0 40px #ff003c80" }}
+        >
+          INTEGRITY BREACH
+        </h1>
+
+        {/* Divider */}
+        <div className="w-full h-px" style={{ background: "linear-gradient(90deg, transparent, #ff003c, transparent)" }} />
+
+        {/* Details */}
+        <div className="flex flex-col gap-3 font-mono text-sm" style={{ color: "#ff6080" }}>
+          <p className="text-base" style={{ color: "#ffb0c0" }}>
+            Tampered storage detected. The system has flagged your session.
+          </p>
+          <p>
+            Compromised key:{" "}
+            <span
+              className="px-2 py-0.5 rounded text-xs"
+              style={{ background: "#ff003c22", color: "#ff4060", border: "1px solid #ff003c44" }}
+            >
+              {tamperKey}
+            </span>
+          </p>
+          <p style={{ color: "#884050" }}>
+            All achievement data has been invalidated.
+          </p>
+        </div>
+
+        {/* Acknowledge button */}
+        <button
+          className="mt-4 px-8 py-3 font-mono text-sm uppercase tracking-widest rounded cursor-pointer transition-all duration-150"
+          style={{
+            background: "#ff003c18",
+            border: "1px solid #ff003c",
+            color: "#ff6080",
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = "#ff003c33";
+            (e.currentTarget as HTMLButtonElement).style.color = "#ffb0c0";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.background = "#ff003c18";
+            (e.currentTarget as HTMLButtonElement).style.color = "#ff6080";
+          }}
+          onClick={() => window.location.reload()}
+        >
+          [ I was cheating. Reload. ]
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/__tests__/anti-cheat.test.ts
+++ b/packages/core/src/__tests__/anti-cheat.test.ts
@@ -18,7 +18,11 @@ function makeAdapter() {
 }
 
 function makeEngine(storage = makeAdapter(), onTamperDetected?: (key: string) => void) {
-  return createAchievements({ definitions, storage, onTamperDetected });
+  return createAchievements({
+    definitions,
+    storage,
+    ...(onTamperDetected && { onTamperDetected }),
+  });
 }
 
 describe("fnv1aHashAdapter", () => {

--- a/packages/core/src/__tests__/anti-cheat.test.ts
+++ b/packages/core/src/__tests__/anti-cheat.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from "vitest";
+import { createAchievements } from "../engine";
+import { fnv1aHashAdapter, inMemoryAdapter } from "../adapters";
+
+const definitions = [
+  { id: "basic", label: "Basic", description: "A basic achievement" },
+  {
+    id: "progress-many",
+    label: "Progress Many",
+    description: "Many steps needed",
+    maxProgress: 10,
+  },
+  { id: "collectible", label: "Collectible", description: "Collect items", maxProgress: 3 },
+] as const;
+
+function makeAdapter() {
+  return inMemoryAdapter();
+}
+
+function makeEngine(storage = makeAdapter(), onTamperDetected?: (key: string) => void) {
+  return createAchievements({ definitions, storage, onTamperDetected });
+}
+
+describe("fnv1aHashAdapter", () => {
+  it("returns a hex string", () => {
+    const adapter = fnv1aHashAdapter();
+    expect(adapter.hash("hello")).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("is deterministic", () => {
+    const adapter = fnv1aHashAdapter();
+    expect(adapter.hash("test-data")).toBe(adapter.hash("test-data"));
+  });
+
+  it("produces different hashes for different inputs", () => {
+    const adapter = fnv1aHashAdapter();
+    expect(adapter.hash("data-a")).not.toBe(adapter.hash("data-b"));
+  });
+});
+
+describe("hash written alongside data", () => {
+  it("stores a hash key when unlocking an achievement", () => {
+    const adapter = makeAdapter();
+    const engine = makeEngine(adapter);
+    engine.unlock("basic");
+    expect(adapter.get("unlocked:hash")).not.toBeNull();
+  });
+
+  it("stores a hash key when setting progress", () => {
+    const adapter = makeAdapter();
+    const engine = makeEngine(adapter);
+    engine.setProgress("progress-many", 5);
+    expect(adapter.get("progress:hash")).not.toBeNull();
+  });
+
+  it("stores a hash key when collecting items", () => {
+    const adapter = makeAdapter();
+    const engine = makeEngine(adapter);
+    engine.collectItem("collectible", "item-a");
+    expect(adapter.get("items:hash")).not.toBeNull();
+  });
+});
+
+describe("tamper detection at hydration", () => {
+  it("discards tampered unlocked data and starts empty", () => {
+    const adapter = makeAdapter();
+    // Simulate writing data + hash, then tampering with the data
+    adapter.set("unlocked", JSON.stringify(["basic", "progress-many"]));
+    adapter.set("unlocked:hash", "deadbeef"); // wrong hash
+
+    const engine = makeEngine(adapter);
+    expect(engine.isUnlocked("basic")).toBe(false);
+    expect(engine.getUnlockedCount()).toBe(0);
+  });
+
+  it("discards tampered progress data and starts at zero", () => {
+    const adapter = makeAdapter();
+    adapter.set("progress", JSON.stringify({ "progress-many": 9 }));
+    adapter.set("progress:hash", "deadbeef");
+
+    const engine = makeEngine(adapter);
+    expect(engine.getProgress("progress-many")).toBe(0);
+  });
+
+  it("discards tampered items data and starts empty", () => {
+    const adapter = makeAdapter();
+    adapter.set("items", JSON.stringify({ collectible: ["a", "b", "c"] }));
+    adapter.set("items:hash", "deadbeef");
+
+    const engine = makeEngine(adapter);
+    expect(engine.getItems("collectible").size).toBe(0);
+  });
+
+  it("calls onTamperDetected with the affected key", () => {
+    const adapter = makeAdapter();
+    adapter.set("unlocked", JSON.stringify(["basic"]));
+    adapter.set("unlocked:hash", "deadbeef");
+
+    const onTamperDetected = vi.fn();
+    makeEngine(adapter, onTamperDetected);
+
+    expect(onTamperDetected).toHaveBeenCalledWith("unlocked");
+  });
+
+  it("clears tampered data from storage on hydration", () => {
+    const adapter = makeAdapter();
+    adapter.set("unlocked", JSON.stringify(["basic"]));
+    adapter.set("unlocked:hash", "deadbeef");
+
+    makeEngine(adapter);
+
+    expect(adapter.get("unlocked")).toBeNull();
+    expect(adapter.get("unlocked:hash")).toBeNull();
+  });
+
+  it("trusts data with no hash (backward compatibility)", () => {
+    const adapter = makeAdapter();
+    // Data stored without anti-cheat (no hash key)
+    adapter.set("unlocked", JSON.stringify(["basic"]));
+
+    const engine = makeEngine(adapter);
+    expect(engine.isUnlocked("basic")).toBe(true);
+  });
+});
+
+describe("tamper detection before unlock", () => {
+  it("calls onTamperDetected if stored unlocked data is modified between operations", () => {
+    const adapter = makeAdapter();
+    const onTamperDetected = vi.fn();
+    const engine = createAchievements({ definitions, storage: adapter, onTamperDetected });
+
+    // Normal unlock — writes data + hash
+    engine.unlock("basic");
+
+    // Tamper the stored unlocked list (simulate a user editing localStorage)
+    adapter.set("unlocked", JSON.stringify(["basic", "progress-many"]));
+
+    // Next unlock detects the tamper
+    engine.unlock("collectible");
+
+    expect(onTamperDetected).toHaveBeenCalledWith("unlocked");
+  });
+
+  it("still performs the unlock even after tamper detected", () => {
+    const adapter = makeAdapter();
+    const engine = createAchievements({ definitions, storage: adapter });
+
+    engine.unlock("basic");
+    // Tamper the stored unlocked list
+    adapter.set("unlocked", JSON.stringify(["basic", "progress-many"]));
+
+    engine.unlock("collectible");
+
+    // In-memory state (authoritative) should have basic + collectible, not progress-many
+    expect(engine.isUnlocked("basic")).toBe(true);
+    expect(engine.isUnlocked("collectible")).toBe(true);
+    expect(engine.isUnlocked("progress-many")).toBe(false);
+  });
+
+  it("overwrites tampered storage with authoritative in-memory state", () => {
+    const adapter = makeAdapter();
+    const engine = createAchievements({ definitions, storage: adapter });
+
+    engine.unlock("basic");
+    adapter.set("unlocked", JSON.stringify(["basic", "progress-many"]));
+
+    engine.unlock("collectible");
+
+    // Storage should now reflect only what the engine actually unlocked
+    const stored = JSON.parse(adapter.get("unlocked")!) as string[];
+    expect(stored).toContain("basic");
+    expect(stored).toContain("collectible");
+    expect(stored).not.toContain("progress-many");
+  });
+});
+
+describe("reset clears hash keys", () => {
+  it("removes hash keys for all storage keys", () => {
+    const adapter = makeAdapter();
+    const removeSpy = vi.spyOn(adapter, "remove");
+    const engine = createAchievements({ definitions, storage: adapter });
+
+    engine.unlock("basic");
+    engine.setProgress("progress-many", 5);
+    engine.collectItem("collectible", "item-a");
+    engine.reset();
+
+    expect(removeSpy).toHaveBeenCalledWith("unlocked:hash");
+    expect(removeSpy).toHaveBeenCalledWith("progress:hash");
+    expect(removeSpy).toHaveBeenCalledWith("items:hash");
+  });
+});
+
+describe("custom hash adapter", () => {
+  it("uses the provided hash adapter instead of the default", () => {
+    const customHash = vi.fn((data: string) => `custom:${data.length}`);
+    const adapter = makeAdapter();
+    const engine = createAchievements({
+      definitions,
+      storage: adapter,
+      hash: { hash: customHash },
+    });
+
+    engine.unlock("basic");
+
+    expect(customHash).toHaveBeenCalled();
+    expect(adapter.get("unlocked:hash")).toMatch(/^custom:/);
+  });
+
+  it("validates stored data using the same custom hash adapter", () => {
+    const adapter = makeAdapter();
+    // Write data + hash using custom adapter
+    const customAdapter = { hash: (data: string) => `x${data.length}` };
+    const e1 = createAchievements({ definitions, storage: adapter, hash: customAdapter });
+    e1.unlock("basic");
+
+    // New engine with same custom adapter should trust the data
+    const onTamperDetected = vi.fn();
+    const e2 = createAchievements({
+      definitions,
+      storage: adapter,
+      hash: customAdapter,
+      onTamperDetected,
+    });
+    expect(e2.isUnlocked("basic")).toBe(true);
+    expect(onTamperDetected).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -1,4 +1,4 @@
-import type { StorageAdapter } from "./types";
+import type { HashAdapter, StorageAdapter } from "./types";
 
 export function localStorageAdapter(prefix?: string): StorageAdapter {
   const k = (key: string) => (prefix ? `${prefix}:${key}` : key);
@@ -26,6 +26,23 @@ export function localStorageAdapter(prefix?: string): StorageAdapter {
       } catch {
         // Storage unavailable — silently ignore
       }
+    },
+  };
+}
+
+/**
+ * Default hash adapter using FNV-1a (32-bit).
+ * Fast, synchronous, and sufficient for tamper detection.
+ */
+export function fnv1aHashAdapter(): HashAdapter {
+  return {
+    hash(data: string): string {
+      let h = 2166136261; // FNV-1a offset basis
+      for (let i = 0; i < data.length; i++) {
+        h ^= data.charCodeAt(i);
+        h = Math.imul(h, 16777619) >>> 0; // FNV prime, keep 32-bit unsigned
+      }
+      return h.toString(16);
     },
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
 export { createAchievements } from "./engine";
-export { localStorageAdapter, inMemoryAdapter } from "./adapters";
+export { localStorageAdapter, inMemoryAdapter, fnv1aHashAdapter } from "./adapters";
 export { defineAchievements } from "./types";
-export type { AchievementDef, AchievementState, AchievementEngine, StorageAdapter } from "./types";
+export type {
+  AchievementDef,
+  AchievementState,
+  AchievementEngine,
+  StorageAdapter,
+  HashAdapter,
+} from "./types";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export type {
   StorageAdapter,
   HashAdapter,
 } from "./types";
+export type { Config as AchievementsConfig } from "./engine";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,11 @@ export type StorageAdapter = {
   remove(key: string): void;
 };
 
+// Pluggable hash function for tamper detection
+export type HashAdapter = {
+  hash(data: string): string;
+};
+
 // The object returned by createAchievements()
 export type AchievementEngine<TId extends string> = {
   // --- Writes ---

--- a/packages/react/src/factory.tsx
+++ b/packages/react/src/factory.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { createAchievements as coreCreate } from "achievements";
-import type { AchievementDef, HashAdapter, StorageAdapter } from "achievements";
+import type { AchievementsConfig } from "achievements";
 import { AchievementsProvider } from "./context";
 import {
   useAchievements as useAchievementsHook,
@@ -10,15 +10,6 @@ import {
   useAchievementToast as useAchievementToastHook,
   useUnlockedCount as useUnlockedCountHook,
 } from "./hooks";
-
-type Config<TId extends string> = {
-  definitions: ReadonlyArray<AchievementDef<TId>>;
-  storage?: StorageAdapter;
-  hash?: HashAdapter;
-  onUnlock?: (id: TId) => void;
-  /** Called when stored data fails its integrity check. For React consumers, prefer useTamperDetected(). */
-  onTamperDetected?: (key: string) => void;
-};
 
 /**
  * Factory that creates the engine and returns hooks already bound to TId.
@@ -33,7 +24,7 @@ type Config<TId extends string> = {
  * import { useIsUnlocked } from './achievements'
  * const unlocked = useIsUnlocked('night-owl') // fully typed, no <T> needed
  */
-export function createAchievements<TId extends string>(config: Config<TId>) {
+export function createAchievements<TId extends string>(config: AchievementsConfig<TId>) {
   // Buffer the first tamper key so useTamperDetected() works even when tamper is
   // detected at module load time, before any React component has mounted.
   let _tamperKey: string | null = null;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,4 +22,5 @@ export type {
   AchievementEngine,
   StorageAdapter,
   HashAdapter,
+  AchievementsConfig,
 } from "achievements";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,10 +14,12 @@ export {
   createAchievements as createAchievementsEngine,
   localStorageAdapter,
   inMemoryAdapter,
+  fnv1aHashAdapter,
 } from "achievements";
 export type {
   AchievementDef,
   AchievementState,
   AchievementEngine,
   StorageAdapter,
+  HashAdapter,
 } from "achievements";


### PR DESCRIPTION
## Summary

- Add `HashAdapter` interface — pluggable hash function, mirrors the `StorageAdapter` pattern
- Add `fnv1aHashAdapter` default implementation (FNV-1a 32-bit, synchronous, no dependencies)
- Engine stores a hash alongside every persisted value (`unlocked`, `progress`, `items`) using a `<key>:hash` storage key
- On hydration, each field is verified against its hash; tampered data is discarded and `onTamperDetected` is called
- `unlock()` re-verifies stored data before writing, catching real-time edits to storage while the app is running
- `reset()` cleans up hash keys alongside data keys
- React factory intercepts `onTamperDetected` internally and exposes `useTamperDetected()` hook — handles both hydration-time tamper (before React mounts) and runtime tamper, with no manual wiring needed
- Example app: renders a full-screen `JumpscarePage` on tamper detection via `useTamperDetected()`
- 18 new tests covering hash writes, tamper detection at hydration, runtime detection, reset, and custom adapters

## Test plan

- [x] Run `pnpm --filter achievements test` — all 48 tests pass
- [x] Open the example app, unlock some achievements, manually edit a localStorage value in DevTools, reload — jumpscare page appears
- [ ] Click "I was cheating. Reload." — app reloads cleanly (tampered data was cleared on detection)
- [ ] Edit a localStorage value while the app is running (without reload), then trigger any action that calls `unlock()` — jumpscare page appears immediately