### PR TITLE
feat: shadcn/ui example app + fix anti-cheat item restoration

### DIFF
--- a/apps/example/components.json
+++ b/apps/example/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -9,10 +9,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-progress": "1.1.8",
+    "@radix-ui/react-scroll-area": "1.2.10",
+    "@radix-ui/react-separator": "1.1.8",
+    "@radix-ui/react-slot": "1.2.4",
+    "@radix-ui/react-toast": "1.2.15",
     "achievements": "workspace:*",
     "achievements-react": "workspace:*",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "lucide-react": "0.575.0",
     "react": "catalog:",
-    "react-dom": "19.2.0"
+    "react-dom": "19.2.0",
+    "tailwind-merge": "3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.2.1",

--- a/apps/example/src/components/AchievementCard.tsx
+++ b/apps/example/src/components/AchievementCard.tsx
@@ -1,7 +1,10 @@
 import type { AchievementDef } from "achievements";
 import { useIsUnlocked, useProgress } from "../achievements";
 import type { AchievementId } from "../achievements";
-import { ProgressBar } from "./ProgressBar";
+import { Progress } from "./ui/progress";
+import { Badge } from "./ui/badge";
+import { Card } from "./ui/card";
+import { cn } from "@/lib/utils";
 
 type Props = { def: AchievementDef<AchievementId> };
 
@@ -11,14 +14,14 @@ export function AchievementCard({ def }: Props) {
   const secret = !!def.hidden && !unlocked;
 
   return (
-    <article
-      className={[
-        "p-3.5 rounded-xl border transition-all duration-300",
+    <Card
+      className={cn(
+        "p-3.5 transition-all duration-300",
         unlocked
-          ? "bg-surface border-accent-mid shadow-[0_0_12px_rgba(61,255,176,0.07)]"
-          : "bg-surface border-edge",
-        secret ? "opacity-55" : "",
-      ].join(" ")}
+          ? "border-accent-mid shadow-[0_0_12px_rgba(61,255,176,0.07)]"
+          : "border-edge",
+        secret && "opacity-55"
+      )}
     >
       {/* Top row: glyph · id · badge */}
       <div className="flex items-center gap-2 mb-2">
@@ -32,16 +35,9 @@ export function AchievementCard({ def }: Props) {
         >
           {secret ? "CLASSIFIED" : def.id}
         </code>
-        <span
-          className={[
-            "font-mono text-[9px] tracking-widest px-1.5 py-0.5 rounded border whitespace-nowrap",
-            unlocked
-              ? "bg-accent-dim text-accent border-accent-mid"
-              : "bg-well text-faint border-edge",
-          ].join(" ")}
-        >
+        <Badge variant={unlocked ? "unlocked" : "default"}>
           {unlocked ? "UNLOCKED" : "LOCKED"}
-        </span>
+        </Badge>
       </div>
 
       {/* Label */}
@@ -65,12 +61,12 @@ export function AchievementCard({ def }: Props) {
       {/* Progress bar */}
       {max !== undefined && !secret && (
         <div className="flex items-center gap-2.5 mt-2.5">
-          <ProgressBar value={progress} max={max} className="flex-1" />
+          <Progress value={(progress / max) * 100} className="flex-1 h-[3px]" />
           <span className="font-mono text-[10px] text-faint whitespace-nowrap">
             {progress}&thinsp;/&thinsp;{max}
           </span>
         </div>
       )}
-    </article>
+    </Card>
   );
 }

--- a/apps/example/src/components/ClickFrenzySection.tsx
+++ b/apps/example/src/components/ClickFrenzySection.tsx
@@ -1,5 +1,6 @@
 import { useAchievements, useIsUnlocked, useProgress } from "../achievements";
-import { ProgressBar } from "./ProgressBar";
+import { Progress } from "./ui/progress";
+import { Button } from "./ui/button";
 
 export function ClickFrenzySection() {
   const { incrementProgress } = useAchievements();
@@ -22,30 +23,22 @@ export function ClickFrenzySection() {
       </p>
 
       <div className="flex items-center gap-5 flex-wrap">
-        <button
-          className={[
-            "min-w-[120px] px-7 py-3.5 flex flex-col items-center gap-1",
-            "bg-well border rounded-xl transition-all duration-150",
-            unlocked
-              ? "border-accent-mid bg-accent-dim cursor-default"
-              : "border-edge-bright cursor-pointer hover:border-accent-mid hover:bg-accent-dim active:scale-95",
-          ].join(" ")}
+        <Button
+          variant={unlocked ? "accent" : "outline"}
+          size="lg"
+          className="min-w-[120px] flex-col gap-1 h-auto py-3.5"
           onClick={() => incrementProgress("click-frenzy")}
           disabled={unlocked}
         >
-          <span
-            className={`font-mono text-[14px] tracking-[0.12em] ${
-              unlocked ? "text-accent" : "text-bright"
-            }`}
-          >
+          <span className="tracking-[0.12em]">
             {unlocked ? "COMPLETE" : "CLICK"}
           </span>
-          <span className="font-mono text-[11px] text-faint">
+          <span className="text-[11px] font-normal opacity-70">
             {progress}&thinsp;/&thinsp;{max}
           </span>
-        </button>
+        </Button>
 
-        <ProgressBar value={progress} max={max} className="flex-1 min-w-[160px] h-1!" />
+        <Progress value={(progress / max) * 100} className="flex-1 min-w-[160px] h-1!" />
       </div>
     </section>
   );

--- a/apps/example/src/components/CollectorSection.tsx
+++ b/apps/example/src/components/CollectorSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { engine, useAchievements, useIsUnlocked, useProgress } from "../achievements";
+import { Button } from "./ui/button";
 
 const INITIAL_NODES = [
   { id: "node-alpha", label: "alpha", desc: "Primary relay" },
@@ -64,23 +65,17 @@ export function CollectorSection() {
           const done = scanned.has(node.id);
           const allDone = coverageUnlocked;
           return (
-            <button
+            <Button
               key={node.id}
-              className={[
-                "p-4 flex flex-col gap-1.5 text-left rounded-xl border transition-all duration-150",
-                done || allDone
-                  ? "border-accent-mid bg-accent-dim cursor-default"
-                  : "border-edge bg-surface cursor-pointer hover:border-edge-bright hover:bg-well",
-              ].join(" ")}
+              variant={done || allDone ? "accent" : "outline"}
+              className="h-auto p-4 flex flex-col items-start gap-1.5"
               onClick={() => scan(node.id)}
               disabled={done || allDone}
             >
-              <span
-                className={`font-mono text-[13px] ${done ? "text-accent" : "text-bright"}`}
-              >
-                {node.label}
+              <span className="font-mono text-[13px]">{node.label}</span>
+              <span className="text-[11px] text-faint leading-snug font-normal">
+                {node.desc}
               </span>
-              <span className="text-[11px] text-faint leading-snug">{node.desc}</span>
               <span
                 className={`font-mono text-[10px] mt-1 tracking-wide ${
                   done ? "text-accent-mid" : "text-faint"
@@ -88,7 +83,7 @@ export function CollectorSection() {
               >
                 {done ? "✓ scanned" : "→ scan"}
               </span>
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -102,12 +97,9 @@ export function CollectorSection() {
         </p>
 
         {!expanded && !coverageUnlocked && (
-          <button
-            className="font-mono text-[11px] text-faint border border-edge rounded px-2.5 py-1 hover:text-bright hover:border-edge-bright transition-all duration-150 cursor-pointer"
-            onClick={() => setExpanded(true)}
-          >
+          <Button variant="ghost" size="sm" onClick={() => setExpanded(true)}>
             + expand network
-          </button>
+          </Button>
         )}
       </div>
 

--- a/apps/example/src/components/ExplorerSection.tsx
+++ b/apps/example/src/components/ExplorerSection.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useAchievements, useIsUnlocked, useProgress } from "../achievements";
+import { Button } from "./ui/button";
+import { cn } from "@/lib/utils";
 
 const MODULES = [
   { id: "core", label: "core", desc: "Engine · types · factory" },
@@ -38,23 +40,20 @@ export function ExplorerSection() {
         {MODULES.map((mod) => {
           const done = visited.has(mod.id);
           return (
-            <button
+            <Button
               key={mod.id}
-              className={[
-                "p-4 flex flex-col gap-1.5 text-left rounded-xl border transition-all duration-150",
-                done || unlocked
-                  ? "border-accent-mid bg-accent-dim cursor-default"
-                  : "border-edge bg-surface cursor-pointer hover:border-edge-bright hover:bg-well",
-              ].join(" ")}
+              variant={done || unlocked ? "accent" : "outline"}
+              className={cn(
+                "h-auto p-4 flex flex-col items-start gap-1.5",
+                !(done || unlocked) && "hover:bg-well"
+              )}
               onClick={() => visit(mod.id)}
               disabled={done || unlocked}
             >
-              <span
-                className={`font-mono text-[13px] ${done ? "text-accent" : "text-bright"}`}
-              >
-                {mod.label}
+              <span className="font-mono text-[13px]">{mod.label}</span>
+              <span className="text-[11px] text-faint leading-snug font-normal">
+                {mod.desc}
               </span>
-              <span className="text-[11px] text-faint leading-snug">{mod.desc}</span>
               <span
                 className={`font-mono text-[10px] mt-1 tracking-wide ${
                   done ? "text-accent-mid" : "text-faint"
@@ -62,7 +61,7 @@ export function ExplorerSection() {
               >
                 {done ? "✓ visited" : "→ visit"}
               </span>
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/apps/example/src/components/ManualSection.tsx
+++ b/apps/example/src/components/ManualSection.tsx
@@ -1,5 +1,6 @@
 import { useAchievements, useIsUnlocked } from "../achievements";
 import type { AchievementId } from "../achievements";
+import { Button } from "./ui/button";
 
 type TriggerProps = {
   id: AchievementId;
@@ -11,14 +12,9 @@ function ManualTrigger({ id, desc }: TriggerProps) {
   const unlocked = useIsUnlocked(id);
 
   return (
-    <button
-      className={[
-        "grid [grid-template-columns:1fr_auto] [grid-template-rows:auto_auto] gap-x-4 gap-y-0.5",
-        "px-5 py-4 text-left rounded-xl border transition-all duration-150 max-w-[480px]",
-        unlocked
-          ? "border-accent-mid bg-accent-dim cursor-default"
-          : "border-edge bg-surface cursor-pointer hover:border-edge-bright hover:bg-well",
-      ].join(" ")}
+    <Button
+      variant={unlocked ? "accent" : "outline"}
+      className="grid [grid-template-columns:1fr_auto] [grid-template-rows:auto_auto] gap-x-4 gap-y-0.5 h-auto px-5 py-4 text-left max-w-[480px]"
       onClick={() => unlock(id)}
       disabled={unlocked}
     >
@@ -29,7 +25,9 @@ function ManualTrigger({ id, desc }: TriggerProps) {
       >
         {id}
       </code>
-      <span className="text-[12px] text-faint col-start-1 row-start-2">{desc}</span>
+      <span className="text-[12px] text-faint col-start-1 row-start-2 font-normal">
+        {desc}
+      </span>
       <span
         className={`font-mono text-[10px] col-start-2 row-span-2 self-center whitespace-nowrap tracking-wide ${
           unlocked ? "text-accent-mid" : "text-faint"
@@ -37,7 +35,7 @@ function ManualTrigger({ id, desc }: TriggerProps) {
       >
         {unlocked ? "✓ unlocked" : "→ trigger"}
       </span>
-    </button>
+    </Button>
   );
 }
 

--- a/apps/example/src/components/ProgressBar.tsx
+++ b/apps/example/src/components/ProgressBar.tsx
@@ -1,19 +1,13 @@
+import { Progress } from "./ui/progress";
+import { cn } from "@/lib/utils";
+
 type Props = {
   value: number;
   max: number;
   className?: string;
 };
 
-export function ProgressBar({ value, max, className = "" }: Props) {
+export function ProgressBar({ value, max, className }: Props) {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
-  return (
-    <div
-      className={`h-[3px] bg-well rounded-full overflow-hidden ${className}`}
-    >
-      <div
-        className="prog-fill h-full bg-accent rounded-full transition-[width] duration-100 ease-out relative"
-        style={{ width: `${pct}%` }}
-      />
-    </div>
-  );
+  return <Progress value={pct} className={cn("h-[3px]", className)} />;
 }

--- a/apps/example/src/components/Sidebar.tsx
+++ b/apps/example/src/components/Sidebar.tsx
@@ -1,5 +1,7 @@
 import { useAchievements, useUnlockedCount, definitions } from "../achievements";
 import { AchievementCard } from "./AchievementCard";
+import { ScrollArea } from "./ui/scroll-area";
+import { Button } from "./ui/button";
 
 export function Sidebar() {
   const { reset } = useAchievements();
@@ -18,23 +20,21 @@ export function Sidebar() {
       </header>
 
       {/* Card list */}
-      <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-2 [scrollbar-width:thin] [scrollbar-color:var(--color-edge)_transparent]">
-        {definitions.map((def) => (
-          <AchievementCard
-            key={def.id}
-            def={def}
-          />
-        ))}
-      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-3 flex flex-col gap-2">
+          {definitions.map((def) => (
+            <AchievementCard key={def.id} def={def} />
+          ))}
+        </div>
+      </ScrollArea>
 
       {/* Reset — engine.reset() clears all storage, so the next page load
           will see first-visit as not unlocked, correctly treating it as a new session. */}
-      <button
-        className="shrink-0 m-3 px-4 py-2.5 bg-transparent border border-edge rounded text-faint font-mono text-[12px] tracking-wide cursor-pointer transition-colors hover:border-edge-bright hover:text-body"
-        onClick={reset}
-      >
-        ⟳&ensp;reset all
-      </button>
+      <div className="shrink-0 m-3">
+        <Button variant="ghost" size="sm" className="w-full" onClick={reset}>
+          ⟳&ensp;reset all
+        </Button>
+      </div>
     </aside>
   );
 }

--- a/apps/example/src/components/Toast.tsx
+++ b/apps/example/src/components/Toast.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { engine, useAchievementToast } from "../achievements";
+import { Card } from "./ui/card";
+import { Button } from "./ui/button";
 
 const DISPLAY_MS = 3200;
 const FADE_MS = 400;
@@ -32,31 +34,35 @@ export function Toast() {
   if (!currentId || !def) return null;
 
   return (
-    <div
+    <Card
       className={[
-        "fixed bottom-7 right-7 w-[300px] z-50",
-        "bg-well border border-accent-mid rounded-xl p-4",
+        "fixed bottom-7 right-7 w-[300px] z-50 p-4",
+        "border-accent-mid",
         "shadow-[0_0_0_1px_rgba(61,255,176,0.08),0_24px_48px_rgba(0,0,0,0.5),0_0_32px_rgba(61,255,176,0.06)]",
         "transition-all duration-300",
-        visible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-3 scale-[0.97]",
+        visible
+          ? "opacity-100 translate-y-0 scale-100"
+          : "opacity-0 translate-y-3 scale-[0.97]",
       ].join(" ")}
     >
       <div className="flex items-center justify-between mb-2">
         <span className="font-mono text-[10px] tracking-widest text-accent">
           // achievement unlocked
         </span>
-        <button
-          className="text-faint text-[12px] leading-none px-0.5 transition-colors hover:text-body"
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-5 rounded text-[12px] border-transparent"
           onClick={close}
         >
           ✕
-        </button>
+        </Button>
       </div>
 
       <div className="text-[15px] font-semibold tracking-tight text-bright mb-1">
         {def.label}
       </div>
       <div className="text-[12px] leading-relaxed text-body">{def.description}</div>
-    </div>
+    </Card>
   );
 }

--- a/apps/example/src/components/ui/badge.tsx
+++ b/apps/example/src/components/ui/badge.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+        unlocked:
+          "bg-accent-dim text-accent border-accent-mid",
+        locked:
+          "bg-well text-faint border-edge",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/example/src/components/ui/button.tsx
+++ b/apps/example/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+        accent:
+          "bg-accent-dim border border-accent-mid text-accent hover:bg-accent-dim/80",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/apps/example/src/components/ui/card.tsx
+++ b/apps/example/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/apps/example/src/components/ui/progress.tsx
+++ b/apps/example/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/apps/example/src/components/ui/scroll-area.tsx
+++ b/apps/example/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/apps/example/src/components/ui/separator.tsx
+++ b/apps/example/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/apps/example/src/index.css
+++ b/apps/example/src/index.css
@@ -23,6 +23,27 @@
   --color-bright: #c8dcea;
   --color-faint:  #3a5060;
   --color-code:   #5bc8a0;
+
+  /* shadcn semantic mappings */
+  --color-background:            #0b0f12;
+  --color-foreground:            #c8dcea;
+  --color-card:                  #0b0f12;
+  --color-card-foreground:       #c8dcea;
+  --color-popover:               #111820;
+  --color-popover-foreground:    #c8dcea;
+  --color-primary:               #3dffb0;
+  --color-primary-foreground:    #06080a;
+  --color-secondary:             #111820;
+  --color-secondary-foreground:  #8aa0b4;
+  --color-muted:                 #111820;
+  --color-muted-foreground:      #3a5060;
+  --color-accent-foreground:     #06080a;
+  --color-destructive:           #ef4444;
+  --color-destructive-foreground: #fafafa;
+  --color-border:                #1c2a38;
+  --color-input:                 #1c2a38;
+  --color-ring:                  #27a86d;
+  --radius:                      0.75rem;
 }
 
 html, body, #root {

--- a/apps/example/src/lib/utils.ts
+++ b/apps/example/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react-jsx",
     "noEmit": true,
     "paths": {
+      "@/*": ["./src/*"],
       "achievements": ["../../packages/core/src/index.ts"],
       "achievements-react": ["../../packages/react/src/index.ts"]
     }

--- a/apps/example/vite.config.ts
+++ b/apps/example/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
+      "@": resolve(__dirname, "./src"),
       achievements: resolve(__dirname, "../../packages/core/src/index.ts"),
       "achievements-react": resolve(__dirname, "../../packages/react/src/index.ts"),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,18 +41,45 @@ importers:
 
   apps/example:
     dependencies:
+      '@radix-ui/react-progress':
+        specifier: 1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-scroll-area':
+        specifier: 1.2.10
+        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-separator':
+        specifier: 1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot':
+        specifier: 1.2.4
+        version: 1.2.4(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-toast':
+        specifier: 1.2.15
+        version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       achievements:
         specifier: workspace:*
         version: link:../../packages/core
       achievements-react:
         specifier: workspace:*
         version: link:../../packages/react
+      class-variance-authority:
+        specifier: 0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: 0.575.0
+        version: 0.575.0(react@19.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.0
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      tailwind-merge:
+        specifier: 3.5.0
+        version: 3.5.0
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.2.1
@@ -607,6 +634,254 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.8':
+    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.5':
     resolution: {integrity: sha512-zCEmUrt1bggwgBgeKLxNj217J1OrChrp3jJt24VK9jAharSTeVaHODNL+LpcQVhRz+FktYWfT9cjo5oZ99ZLpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -993,6 +1268,13 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1203,6 +1485,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.575.0:
+    resolution: {integrity: sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1291,6 +1578,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -1764,6 +2054,210 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.50.0':
     optional: true
 
+  '@radix-ui/number@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.4)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.4)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.4)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.4
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
+
   '@rolldown/binding-android-arm64@1.0.0-rc.5':
     optional: true
 
@@ -2061,6 +2555,12 @@ snapshots:
 
   chai@6.2.2: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  clsx@2.1.1: {}
+
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
@@ -2232,6 +2732,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@0.575.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2372,6 +2876,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
 


### PR DESCRIPTION
## Summary

- Rework the example app to use shadcn/ui components (Button, Card, Progress, Badge, ScrollArea, Separator) pulled via the shadcn CLI and wired to the existing dark/neon theme
- Fix a consistency bug in the anti-cheat engine where only the tampered storage key was wiped, leaving progress and unlocked state intact and creating an impossible partial state after reload

## Changes

### `apps/example` — shadcn/ui integration
- Add `components.json`, `src/lib/utils.ts` (`cn` helper), and `src/components/ui/` with 6 official shadcn components
- Map shadcn semantic tokens (`primary`, `card`, `border`, `ring`, etc.) to the existing `@theme` color variables in `index.css`
- Extend Button with an `accent` variant and Badge with `unlocked`/`locked` variants needed by the app
- Add `@` path alias in `vite.config.ts` and `tsconfig.json`
- Replace raw `<button>`, `<div>`, `<article>` elements in all components with shadcn primitives

### `packages/core` — anti-cheat fix
- Previously `hydrateField` wiped only the one tampered key, leaving the other two in storage. After reload: engine loaded stale `progress`/`unlocked` while `items` was empty — inconsistent state (e.g. `scannerProgress = 2` but `getItems("scanner")` empty)
- Now `hydrateField` returns a tamper flag instead of removing data itself. If any field fails its hash check, **all three keys** (unlocked, progress, items) are wiped together so the next page load always starts from a fully clean slate
- All 48 existing tests (including anti-cheat suite) pass

## Test plan
- [x] Run `pnpm test` in `packages/core` — 48 tests green
- [x] Run `pnpm build` in `apps/example` — Vite builds cleanly
- [x] Start dev server, verify all 4 demo sections work and achievements unlock/persist correctly
- [x] Trigger anti-cheat by modifying a localStorage key in DevTools, confirm JumpscarePage shows and after reload the app starts from a clean state with no inconsistent progress/item data