### PR TITLE
chore: bump version to 0.3.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.0 (2026-02-27)
+
+### Features
+
+- **Anti-cheat system** — pluggable `HashAdapter` interface for tamper detection. Pass a `hashAdapter` to `createAchievements` / `createAchievementsFactory` to sign and verify stored state. A built-in `WebCryptoHashAdapter` (HMAC-SHA-256) is provided out of the box. When tamper is detected, `onTamperDetected` fires with the offending key.
+
+### Bug Fixes
+
+- **Anti-cheat item restoration** — when any storage field fails integrity verification, all three keys (`unlocked`, `progress`, `items`) are now wiped atomically after hydration instead of individually. This prevents partial state (e.g. items cleared but stale progress remaining) after a tamper event.
+
+### Docs
+
+- Added comprehensive README for `achievements` (core) and `achievements-react` packages, and the root monorepo.
+
 ## 0.2.0 (2026-02-26)
 
 ### Features

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "achievements",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Type-safe, framework-agnostic achievement tracking library for web applications",
   "keywords": [
     "achievements",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "achievements-react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React 19+ bindings for the achievements library with hooks and factory",
   "keywords": [
     "achievements",


### PR DESCRIPTION
## Summary

- Bump `achievements` and `achievements-react` packages from `0.2.0` to `0.3.0`
- Prepend `0.3.0` entry to `CHANGELOG.md`

## Changes since 0.2.0

- **feat (#11)**: Anti-cheat system with pluggable `HashAdapter` interface (HMAC-SHA-256 via `WebCryptoHashAdapter`)
- **fix (#13)**: Atomic storage wipe on tamper detection — all three keys wiped together to prevent partial state
- **docs (#12)**: Comprehensive README for core, react, and root monorepo packages